### PR TITLE
Paramètres optionnels

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,15 @@ Pour utiliser le template, il est possible de recopier le fichier exemple.
 
 ### Expéditeur 
 
-- `expediteur.nom` : nom de famille de l'expéditeur·ice, **requis**.
 - `expediteur.prenom` : prénom de l'expéditeur·ice, **requis**.
+- `expediteur.nom` : nom de famille de l'expéditeur·ice, **requis**.
 - `expediteur.voie` : numéro de voie et nom de la voie, **requis**.
 - `expediteur.complement_adresse` : la seconde ligne parfois requise dans une adresse, *facultatif*.
 - `expediteur.code_postal` : code postal, **requis**.
 - `expediteur.commune` : commune de l'expéditeur·ice, **requis**.
--  `expediteur.telephone` : numéro de téléphone. Le format est libre et l'affichage en police mono. *Facultatif*.
--  `expediteur.email` : l'email fourni sera affiché en police mono et cliquable. *Facultatif*
+- `expediteur.pays` : pays de l'expéditeur⋅ice, *facultatif*.
+-  `expediteur.telephone` : le numéro de téléphone fourni sera cliquable. *Chaîne de caractères*, *facultatif*.
+-  `expediteur.email` : l'email fourni sera affiché en police mono et cliquable. *Chaîne de caractères*, *facultatif*.
 - `expediteur.signature` : peut être `true` ou `false`, par défaut `false`. Prévient le paquet qu’une image de signature sera ajoutée, de manière à organiser la superposition de la signature et du nom apposé en fin de courrier.
 
 ## Destinataire
@@ -30,7 +31,8 @@ Pour utiliser le template, il est possible de recopier le fichier exemple.
 - `destinataire.voie` : numéro de voie et nom de la voie, **requis**.
 - `destinataire.complement_adresse` : la seconde ligne parfois requise dans une adresse, *facultatif*.
 - `destinataire.code_postal` : code postal, **requis**.
-- `destinataire.commune` : commune de l'expéditeur·ice, **requis**.
+- `destinataire.commune` : commune du ou de la destinataire, **requis**.
+- `destinataire.pays` : pays du ou de la destinataire, *facultatif*.
 - `destinataire.sc` : si le courrier est envoyé “sous couvert” d'une hiérarchie intermédiaire, spécifier cette autorité. *Facultatif*.
 
 ## Lettre

--- a/src/lib.typ
+++ b/src/lib.typ
@@ -5,8 +5,9 @@
   complement_adresse: [],
   code_postal: [],
   commune: [],
-  telephone: [],
-  email: [],
+  pays: [],
+  telephone: "",  // string, not content: will be processed
+  email: "",      // string, not content: will be processed
   signature: false,
 )
 
@@ -16,6 +17,7 @@
     complement_adresse: [],
     code_postal: [],
     commune: [],
+    pays: [],
     sc: [],
 )
 
@@ -29,25 +31,42 @@
     pj: [],
     doc,
 ) = {
+    // expediteur.prenom is required
+    // expediteur.nom is required
+    expediteur.complement_adresse = expediteur.at("complement_adresse", default: "")
+    // expediteur.voie is required
+    // expediteur.code_postal is required
+    // expediteur.commune is required
+    expediteur.pays = expediteur.at("pays", default: "")
+    expediteur.telephone = expediteur.at("telephone", default: "")
+    expediteur.email = expediteur.at("email", default: "")
+    expediteur.signature = expediteur.at("signature", default: false)
+    // destinataire.titre is required
+    // destinataire.voie is required
+    destinataire.complement_adresse = destinataire.at("complement_adresse", default: "")
+    // destinataire.code_postal is required
+    // destinataire.commune is required
+    destinataire.pays = destinataire.at("pays", default: "")
+    destinataire.sc = destinataire.at("sc", default: "")
     [
         #expediteur.prenom #smallcaps(expediteur.nom) \
         #expediteur.voie #h(1fr) #lieu, #date \
     ]
-    if expediteur.at("complement_adresse", default: "") != "" [
+    if expediteur.complement_adresse != "" and expediteur.complement_adresse != [] [
         #expediteur.complement_adresse \
     ]
     [
         #expediteur.code_postal #expediteur.commune
     ]
-    if expediteur.at("pays", default: "") != "" {
+    if expediteur.pays != "" and expediteur.pays != [] {
         linebreak()
         smallcaps(expediteur.pays)
     }
-    if expediteur.at("telephone", default: "") != "" [
+    if expediteur.telephone != "" [
         #linebreak()
         tél. : #raw(expediteur.telephone)
     ]
-    if expediteur.at("email", default: "") != "" [
+    if expediteur.email != "" [
         #linebreak()
         email : #link("mailto:" + expediteur.email, raw(expediteur.email))
     ]
@@ -59,11 +78,11 @@
         [
             #destinataire.titre \
             #destinataire.voie \
-            #if destinataire.at("complement_adresse", default: "") != "" [
+            #if destinataire.complement_adresse != "" and destinataire.complement_adresse != [] [
                 #destinataire.complement_adresse \
             ]
             #destinataire.code_postal #destinataire.commune
-            #if destinataire.at("sc", default: "") != "" [
+            #if destinataire.sc != "" and destinataire.sc != [] [
                 #v(1cm)
                 s/c de #destinataire.sc \
             ]
@@ -78,14 +97,14 @@
 
     set par(justify: true)
     doc
-    if pj != "" {
+    if pj != "" and pj != [] {
         [
             #v(1cm)
             P. j. : #pj
         ]
     }
 set align(right + horizon)
-    if expediteur.at("signature", default: false) == true {
+    if expediteur.signature {
         v(-3cm)
     }
     [

--- a/src/lib.typ
+++ b/src/lib.typ
@@ -33,7 +33,7 @@
         #expediteur.prenom #smallcaps[#expediteur.nom] \
         #expediteur.voie #h(1fr) #lieu, #date \
     ]
-    if expediteur.complement_adresse != "" {
+    if expediteur.at("complement_adresse", default: "") != "" {
         [
             #expediteur.complement_adresse
             #linebreak()
@@ -42,13 +42,17 @@
     [
         #expediteur.code_postal #expediteur.commune
     ]
-    if expediteur.telephone != "" {
+    if expediteur.at("pays", default: "") != "" {
+        linebreak()
+        smallcaps(expediteur.pays)
+    }
+    if expediteur.at("telephone", default: "") != "" {
         [
             #linebreak()
             tél. : #raw(expediteur.telephone)
         ]
     }
-    if expediteur.email != "" {
+    if expediteur.at("email", default: "") != "" {
         [
             #linebreak()
             email : #link("mailto:" + expediteur.email)[#raw(expediteur.email)]
@@ -62,13 +66,13 @@
         [
             #destinataire.titre \
             #destinataire.voie \
-            #if destinataire.complement_adresse != "" {
+            #if destinataire.at("complement_adresse", default: "") != "" {
                 [
                     #destinataire.complement_adresse \
                 ]
             }
             #destinataire.code_postal #destinataire.commune
-            #if destinataire.sc != "" {
+            #if destinataire.at("sc", default: "") != "" {
                 [
                     #v(1cm)
                     s/c de #destinataire.sc \
@@ -92,7 +96,7 @@
         ]
     }
 set align(right + horizon)
-    if expediteur.signature == true {
+    if expediteur.at("signature", default: false) == true {
         v(-3cm)
     }
     [

--- a/src/lib.typ
+++ b/src/lib.typ
@@ -30,15 +30,12 @@
     doc,
 ) = {
     [
-        #expediteur.prenom #smallcaps[#expediteur.nom] \
+        #expediteur.prenom #smallcaps(expediteur.nom) \
         #expediteur.voie #h(1fr) #lieu, #date \
     ]
-    if expediteur.at("complement_adresse", default: "") != "" {
-        [
-            #expediteur.complement_adresse
-            #linebreak()
-        ]
-    }
+    if expediteur.at("complement_adresse", default: "") != "" [
+        #expediteur.complement_adresse \
+    ]
     [
         #expediteur.code_postal #expediteur.commune
     ]
@@ -46,18 +43,14 @@
         linebreak()
         smallcaps(expediteur.pays)
     }
-    if expediteur.at("telephone", default: "") != "" {
-        [
-            #linebreak()
-            tél. : #raw(expediteur.telephone)
-        ]
-    }
-    if expediteur.at("email", default: "") != "" {
-        [
-            #linebreak()
-            email : #link("mailto:" + expediteur.email)[#raw(expediteur.email)]
-        ]
-    }
+    if expediteur.at("telephone", default: "") != "" [
+        #linebreak()
+        tél. : #raw(expediteur.telephone)
+    ]
+    if expediteur.at("email", default: "") != "" [
+        #linebreak()
+        email : #link("mailto:" + expediteur.email, raw(expediteur.email))
+    ]
     v(1cm)
 
     grid(
@@ -66,18 +59,14 @@
         [
             #destinataire.titre \
             #destinataire.voie \
-            #if destinataire.at("complement_adresse", default: "") != "" {
-                [
-                    #destinataire.complement_adresse \
-                ]
-            }
+            #if destinataire.at("complement_adresse", default: "") != "" [
+                #destinataire.complement_adresse \
+            ]
             #destinataire.code_postal #destinataire.commune
-            #if destinataire.at("sc", default: "") != "" {
-                [
-                    #v(1cm)
-                    s/c de #destinataire.sc \
-                ]
-            }
+            #if destinataire.at("sc", default: "") != "" [
+                #v(1cm)
+                s/c de #destinataire.sc \
+            ]
         ],
     )
 


### PR DESCRIPTION
Deux paramètres de la fonction `lettre` sont des dictionnaires, qui sont optionnels mais dont les clefs sont tout à fait requises : l'absence d'une clef attendue déclenche une erreur.

Il s'agit ici de les rendre optionnelles, en les ajoutant au besoin avec des valeurs par défaut sensées (concrètement, chaîne vide).

J'en ai aussi profité pour simplifier un peu les occurrences de fonctions contenant un bloc de code contenant un contenu, puisqu'on peut dans ce cas directement indiquer le contenu, le bloc de code encadrant étant inutile.