### PR TITLE
Ajout d'un lien téléphonique

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,15 @@ Pour utiliser le template, il est possible de recopier le fichier exemple.
 
 ### Expéditeur 
 
-- `expediteur.nom` : nom de famille de l'expéditeur·ice, **requis**.
 - `expediteur.prenom` : prénom de l'expéditeur·ice, **requis**.
+- `expediteur.nom` : nom de famille de l'expéditeur·ice, **requis**.
 - `expediteur.voie` : numéro de voie et nom de la voie, **requis**.
 - `expediteur.complement_adresse` : la seconde ligne parfois requise dans une adresse, *facultatif*.
 - `expediteur.code_postal` : code postal, **requis**.
 - `expediteur.commune` : commune de l'expéditeur·ice, **requis**.
--  `expediteur.telephone` : numéro de téléphone. Le format est libre et l'affichage en police mono. *Facultatif*.
--  `expediteur.email` : l'email fourni sera affiché en police mono et cliquable. *Facultatif*
+- `expediteur.pays` : pays de l'expéditeur⋅ice, *facultatif*.
+-  `expediteur.telephone` : le numéro de téléphone fourni sera cliquable. *Chaîne de caractères*, *facultatif*.
+-  `expediteur.email` : l'email fourni sera affiché en police mono et cliquable. *Chaîne de caractères*, *facultatif*.
 - `expediteur.signature` : peut être `true` ou `false`, par défaut `false`. Prévient le paquet qu’une image de signature sera ajoutée, de manière à organiser la superposition de la signature et du nom apposé en fin de courrier.
 
 ## Destinataire
@@ -30,7 +31,8 @@ Pour utiliser le template, il est possible de recopier le fichier exemple.
 - `destinataire.voie` : numéro de voie et nom de la voie, **requis**.
 - `destinataire.complement_adresse` : la seconde ligne parfois requise dans une adresse, *facultatif*.
 - `destinataire.code_postal` : code postal, **requis**.
-- `destinataire.commune` : commune de l'expéditeur·ice, **requis**.
+- `destinataire.commune` : commune du ou de la destinataire, **requis**.
+- `destinataire.pays` : pays du ou de la destinataire, *facultatif*.
 - `destinataire.sc` : si le courrier est envoyé “sous couvert” d'une hiérarchie intermédiaire, spécifier cette autorité. *Facultatif*.
 
 ## Lettre

--- a/src/lib.typ
+++ b/src/lib.typ
@@ -45,7 +45,9 @@
     }
     if expediteur.at("telephone", default: "") != "" [
         #linebreak()
-        tél. : #raw(expediteur.telephone)
+        tél. : #link(
+            "tel:"+ expediteur.telephone.replace(" ", "-"),
+            expediteur.telephone)
     ]
     if expediteur.at("email", default: "") != "" [
         #linebreak()

--- a/src/lib.typ
+++ b/src/lib.typ
@@ -33,7 +33,7 @@
         #expediteur.prenom #smallcaps[#expediteur.nom] \
         #expediteur.voie #h(1fr) #lieu, #date \
     ]
-    if expediteur.complement_adresse != "" {
+    if expediteur.at("complement_adresse", default: "") != "" {
         [
             #expediteur.complement_adresse
             #linebreak()
@@ -42,13 +42,17 @@
     [
         #expediteur.code_postal #expediteur.commune
     ]
-    if expediteur.telephone != "" {
+    if expediteur.at("pays", default: "") != "" {
+        linebreak()
+        smallcaps(expediteur.pays)
+    }
+    if expediteur.at("telephone", default: "") != "" {
         [
             #linebreak()
             tél. : #raw(expediteur.telephone)
         ]
     }
-    if expediteur.email != "" {
+    if expediteur.at("email", default: "") != "" {
         [
             #linebreak()
             email : #link("mailto:" + expediteur.email)[#raw(expediteur.email)]
@@ -62,13 +66,13 @@
         [
             #destinataire.titre \
             #destinataire.voie \
-            #if destinataire.complement_adresse != "" {
+            #if destinataire.at("complement_adresse", default: "") != "" {
                 [
                     #destinataire.complement_adresse \
                 ]
             }
             #destinataire.code_postal #destinataire.commune
-            #if destinataire.sc != "" {
+            #if destinataire.at("sc", default: "") != "" {
                 [
                     #v(1cm)
                     s/c de #destinataire.sc \
@@ -92,7 +96,7 @@
         ]
     }
 set align(right + horizon)
-    if expediteur.signature == true {
+    if expediteur.at("signature", default: false) == true {
         v(-3cm)
     }
     [

--- a/src/lib.typ
+++ b/src/lib.typ
@@ -5,8 +5,9 @@
   complement_adresse: [],
   code_postal: [],
   commune: [],
-  telephone: [],
-  email: [],
+  pays: [],
+  telephone: "",  // string, not content: will be processed
+  email: "",      // string, not content: will be processed
   signature: false,
 )
 
@@ -16,6 +17,7 @@
     complement_adresse: [],
     code_postal: [],
     commune: [],
+    pays: [],
     sc: [],
 )
 
@@ -29,27 +31,44 @@
     pj: [],
     doc,
 ) = {
+    // expediteur.prenom is required
+    // expediteur.nom is required
+    expediteur.complement_adresse = expediteur.at("complement_adresse", default: "")
+    // expediteur.voie is required
+    // expediteur.code_postal is required
+    // expediteur.commune is required
+    expediteur.pays = expediteur.at("pays", default: "")
+    expediteur.telephone = expediteur.at("telephone", default: "")
+    expediteur.email = expediteur.at("email", default: "")
+    expediteur.signature = expediteur.at("signature", default: false)
+    // destinataire.titre is required
+    // destinataire.voie is required
+    destinataire.complement_adresse = destinataire.at("complement_adresse", default: "")
+    // destinataire.code_postal is required
+    // destinataire.commune is required
+    destinataire.pays = destinataire.at("pays", default: "")
+    destinataire.sc = destinataire.at("sc", default: "")
     [
         #expediteur.prenom #smallcaps(expediteur.nom) \
         #expediteur.voie #h(1fr) #lieu, #date \
     ]
-    if expediteur.at("complement_adresse", default: "") != "" [
+    if expediteur.complement_adresse != "" and expediteur.complement_adresse != [] [
         #expediteur.complement_adresse \
     ]
     [
         #expediteur.code_postal #expediteur.commune
     ]
-    if expediteur.at("pays", default: "") != "" {
+    if expediteur.pays != "" and expediteur.pays != [] {
         linebreak()
         smallcaps(expediteur.pays)
     }
-    if expediteur.at("telephone", default: "") != "" [
+    if expediteur.telephone != "" [
         #linebreak()
         tél. : #link(
             "tel:"+ expediteur.telephone.replace(" ", "-"),
             expediteur.telephone)
     ]
-    if expediteur.at("email", default: "") != "" [
+    if expediteur.email != "" [
         #linebreak()
         email : #link("mailto:" + expediteur.email, raw(expediteur.email))
     ]
@@ -61,11 +80,11 @@
         [
             #destinataire.titre \
             #destinataire.voie \
-            #if destinataire.at("complement_adresse", default: "") != "" [
+            #if destinataire.complement_adresse != "" and destinataire.complement_adresse != [] [
                 #destinataire.complement_adresse \
             ]
             #destinataire.code_postal #destinataire.commune
-            #if destinataire.at("sc", default: "") != "" [
+            #if destinataire.sc != "" and destinataire.sc != [] [
                 #v(1cm)
                 s/c de #destinataire.sc \
             ]
@@ -80,14 +99,14 @@
 
     set par(justify: true)
     doc
-    if pj != "" {
+    if pj != "" and pj != [] {
         [
             #v(1cm)
             P. j. : #pj
         ]
     }
 set align(right + horizon)
-    if expediteur.at("signature", default: false) == true {
+    if expediteur.signature {
         v(-3cm)
     }
     [

--- a/src/lib.typ
+++ b/src/lib.typ
@@ -30,15 +30,12 @@
     doc,
 ) = {
     [
-        #expediteur.prenom #smallcaps[#expediteur.nom] \
+        #expediteur.prenom #smallcaps(expediteur.nom) \
         #expediteur.voie #h(1fr) #lieu, #date \
     ]
-    if expediteur.at("complement_adresse", default: "") != "" {
-        [
-            #expediteur.complement_adresse
-            #linebreak()
-        ]
-    }
+    if expediteur.at("complement_adresse", default: "") != "" [
+        #expediteur.complement_adresse \
+    ]
     [
         #expediteur.code_postal #expediteur.commune
     ]
@@ -46,18 +43,14 @@
         linebreak()
         smallcaps(expediteur.pays)
     }
-    if expediteur.at("telephone", default: "") != "" {
-        [
-            #linebreak()
-            tél. : #raw(expediteur.telephone)
-        ]
-    }
-    if expediteur.at("email", default: "") != "" {
-        [
-            #linebreak()
-            email : #link("mailto:" + expediteur.email)[#raw(expediteur.email)]
-        ]
-    }
+    if expediteur.at("telephone", default: "") != "" [
+        #linebreak()
+        tél. : #raw(expediteur.telephone)
+    ]
+    if expediteur.at("email", default: "") != "" [
+        #linebreak()
+        email : #link("mailto:" + expediteur.email, raw(expediteur.email))
+    ]
     v(1cm)
 
     grid(
@@ -66,18 +59,14 @@
         [
             #destinataire.titre \
             #destinataire.voie \
-            #if destinataire.at("complement_adresse", default: "") != "" {
-                [
-                    #destinataire.complement_adresse \
-                ]
-            }
+            #if destinataire.at("complement_adresse", default: "") != "" [
+                #destinataire.complement_adresse \
+            ]
             #destinataire.code_postal #destinataire.commune
-            #if destinataire.at("sc", default: "") != "" {
-                [
-                    #v(1cm)
-                    s/c de #destinataire.sc \
-                ]
-            }
+            #if destinataire.at("sc", default: "") != "" [
+                #v(1cm)
+                s/c de #destinataire.sc \
+            ]
         ],
     )
 

--- a/template/src/exemple.typ
+++ b/template/src/exemple.typ
@@ -10,8 +10,8 @@ expediteur: (
   complement_adresse: "",
   code_postal: "33320",
   commune: "Le Taillan-Médoc",
-  telephone: "01 23 45 67 89",
-  email: "etienne@laboetie.org",
+  telephone: "01 99 00 67 89",
+  email: "etienne@laboetie.example",
   signature: false, // indiquez true si ajout d’une image comme signature
 ),
 destinataire: (


### PR DESCRIPTION
Cette PR vient en plus de la #10 qu'elle inclut déjà. Je l'ai séparée parce qu'elle n'est pas forcément consensuelle.

Elle ajoute un lien `tel:` sur le numéro de téléphone. Et, c'est plus discutable, elle supprime le formatage du numéro de téléphone façon code. Autant je conçois que ça puisse être utile pour une adresse électronique, autant pour un numéro de téléphone, je trouve ça moche et je n'en vois pas l'intérêt. Mais comme c'est une question de goût, je n'allais pas mettre ça en douce dans la PR #10 qui n'a rien à voir.