### PR TITLE
Utilisation d'une grille pour la mise en page de l'en-tête

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Pour utiliser le template, il est possible de recopier le fichier exemple.
 - `date` : date à indiquer sous forme libre, **requis**.
 - `lieu` : lieu de rédaction, **requis**.
 - `pj` : permet d'indiquer la présence de pièces jointes.  Il est possible d'en faire une liste, par exemple :
+- `marque_pliage` : `false` par défaut, mettre à `true` pour imprimer une petite ligne indiquant où plier la page pour la mettre dans une enveloppe DL ou C5/6. *Facultatif*.
 
 ```
 pj: [

--- a/src/lib.typ
+++ b/src/lib.typ
@@ -45,7 +45,9 @@
     }
     if expediteur.at("telephone", default: "") != "" [
         #linebreak()
-        tél. : #raw(expediteur.telephone)
+        tél. : #link(
+            "tel:"+ expediteur.telephone.replace(" ", "-"),
+            expediteur.telephone)
     ]
     if expediteur.at("email", default: "") != "" [
         #linebreak()

--- a/src/lib.typ
+++ b/src/lib.typ
@@ -48,51 +48,123 @@
     // destinataire.commune is required
     destinataire.pays = destinataire.at("pays", default: "")
     destinataire.sc = destinataire.at("sc", default: "")
-    [
-        #expediteur.prenom #smallcaps(expediteur.nom) \
-        #expediteur.voie #h(1fr) #lieu, #date \
-    ]
-    if expediteur.complement_adresse != "" and expediteur.complement_adresse != [] [
-        #expediteur.complement_adresse \
-    ]
-    [
-        #expediteur.code_postal #expediteur.commune
-    ]
-    if expediteur.pays != "" and expediteur.pays != [] {
-        linebreak()
-        smallcaps(expediteur.pays)
-    }
-    if expediteur.telephone != "" [
-        #linebreak()
-        tél. : #link(
-            "tel:"+ expediteur.telephone.replace(" ", "-"),
-            expediteur.telephone)
-    ]
-    if expediteur.email != "" [
-        #linebreak()
-        email : #link("mailto:" + expediteur.email, raw(expediteur.email))
-    ]
-    v(1cm)
 
-    grid(
-        columns: (1fr, 5cm),
-        grid.cell(""),
-        [
-            #destinataire.titre \
-            #destinataire.voie \
-            #if destinataire.complement_adresse != "" and destinataire.complement_adresse != [] [
-                #destinataire.complement_adresse \
-            ]
-            #destinataire.code_postal #destinataire.commune
-            #if destinataire.sc != "" and destinataire.sc != [] [
-                #v(1cm)
-                s/c de #destinataire.sc \
-            ]
-        ],
+    // An windowed enveloppe looks like this:
+    //                          220 mm
+    //       ┌───────────────────────────────────────────┐
+    //     ┌ ┌───────────────────────────────────────────┐ ┐
+    //     │ │                                           │ │
+    //     │ │                                           │ │ 45 mm
+    //     │ │                                           │ │
+    //     │ │                   ┌───────────────────┐   │ ┤
+    // 110 │ │                   │                   │   │ │
+    //  mm │ │                   │                   │   │ │ 45 mm
+    //     │ │                   │                   │   │ │
+    //     │ │                   └───────────────────┘   │ ┤
+    //     │ │                                           │ │ 20 mm
+    //     └ └───────────────────────────────────────────┘ ┘
+    //       └───────────────────┴───────────────────┴───┘
+    //            100 mm              100 mm      20 mm
+    //
+    // The folded letter is 210 mm large and 99 mm high, and can
+    // therefore more horizontally by 10 mm and vertically by 11 mm.
+    // This results in the following safe zone for the recipient
+    // address:
+    // ┌───────────────────────────────────────────┐ ┐
+    // │                                           │ │
+    // │                                           │ │ 45 mm
+    // │                                           │ │
+    // │                   ┌───────────────────┐   │ ┤
+    // │                   │                   │   │ │ 34 mm
+    // │                   │                   │   │ │
+    // │                   └───────────────────┘   │ ┤
+    // │                                           │ │ 20 mm
+    // └─────────────── fold ── here ──────────────┘ ┘
+    // └───────────────────┴───────────────────┴───┘
+    //         100 mm              90 mm       20 mm
+    //
+    // We use a (width: 100%, height: 100mm) box containing a grid with
+    // some merged cells to position sender, place and date, and
+    // recipient. Filling rows and columns with fractional dimensions
+    // are here to center the recipient address block within its
+    // window, resulting in a much better-looking layout than just
+    // positionning it statically.
+    // ┌───────────────────────────────────────────┐ ┐
+    // │                  margin                   │ │ 25 mm
+    // │   ┌───────────────┬───────────────────┐   │ ┤ ──────┐
+    // │   │ Sender        │       place, date │   │ │ 20 mm │
+    // │   │ Address       ├───────────────────┤   │ ┤       │
+    // │   │               │     filler #1     │   │ │ 1fr   │
+    // │   │ Phone         ├───┬───────────┬───┤   │ ┤       │
+    // │   │ Email         │f. │ Recipient │f. │   │ │ auto  │
+    // │   │               │#2 │ Address   │#3 │   │ │       │ 75 mm
+    // │   │               ├───┴───────────┴───┤   │ ┤       │
+    // │   │               │     filler #4     │   │ │ 1fr   │
+    // │   ├───────────────┴───────────────────┤   │ ┤       │
+    // │   │            filler #5              │   │ │ 20 mm │
+    // └───┴───────────────────────────────────┴───┘ ┘ ──────┘
+    // └───┴───────────────┴───┴───────────┴───┴───┘
+    // 25mm│     75mm       1fr     auto    1fr│25mm
+    //     └───────────────────────────────────┘
+    //                      100%
+    //
+    block(width: 100%, height: 75mm, spacing: 0pt,
+        grid(
+            columns: (75mm, 1fr, auto, 1fr),
+            rows: (20mm, 1fr, auto, 1fr, 20mm),
+            grid.cell(rowspan: 4,  // sender address and contact info
+                [
+                    #expediteur.prenom #smallcaps(expediteur.nom) \
+                    #expediteur.voie \
+                    #if expediteur.complement_adresse != "" and expediteur.complement_adresse != [] [
+                        #expediteur.complement_adresse \
+                    ]
+                    #expediteur.code_postal #expediteur.commune
+                    #if expediteur.pays != "" and expediteur.pays != [] {
+                        linebreak()
+                        smallcaps(expediteur.pays)
+                    }
+                    #if expediteur.telephone != "" [
+                        #linebreak()
+                        tél. : #link(
+                            "tel:"+ expediteur.telephone.replace(" ", "-"),
+                            expediteur.telephone)
+                    ]
+                    #if expediteur.email != "" [
+                        #linebreak()
+                        email : #link("mailto:" + expediteur.email, raw(expediteur.email))
+                    ]
+                ]
+            ),
+            grid.cell(colspan: 3,  // place and date
+                [
+                    #set align(right)
+                    // place and date should be on second line
+                    #linebreak()
+                    #lieu, #date
+                ]
+            ),
+            grid.cell(colspan: 3, []),  // filler #1
+            grid.cell[],                // filler #2
+            grid.cell[                  // sender address
+                #destinataire.titre \
+                #destinataire.voie \
+                #if destinataire.complement_adresse != "" and destinataire.complement_adresse != [] [
+                    #destinataire.complement_adresse \
+                ]
+                #destinataire.code_postal #destinataire.commune
+                #if destinataire.sc != "" and destinataire.sc != [] [
+                    #v(1cm)
+                    s/c de #destinataire.sc \
+                ]
+            ],
+            grid.cell[],               // filler #3
+            grid.cell(colspan: 3, []), // filler #4
+            grid.cell(colspan: 4, []), // filler #5
+        )
     )
 
-    v(1.7cm)
-
+    v(1em)
     [*Objet : #objet*]
     
     v(0.7cm)

--- a/src/lib.typ
+++ b/src/lib.typ
@@ -29,6 +29,7 @@
     date: [],
     lieu: [],
     pj: [],
+    marque_pliage: false,
     doc,
 ) = {
     // expediteur.prenom is required
@@ -163,6 +164,12 @@
             grid.cell(colspan: 4, []), // filler #5
         )
     )
+
+    if marque_pliage {
+        place(
+            top + left, dx: -25mm, dy: 74mm,
+            line(length: 1cm, stroke: .1pt))
+    }
 
     v(1em)
     [*Objet : #objet*]

--- a/src/lib.typ
+++ b/src/lib.typ
@@ -33,7 +33,7 @@
         #expediteur.prenom #smallcaps[#expediteur.nom] \
         #expediteur.voie #h(1fr) #lieu, #date \
     ]
-    if expediteur.complement_adresse != "" {
+    if expediteur.at("complement_adresse", default: "") != "" {
         [
             #expediteur.complement_adresse
             #linebreak()
@@ -42,13 +42,17 @@
     [
         #expediteur.code_postal #expediteur.commune
     ]
-    if expediteur.telephone != "" {
+    if expediteur.at("pays", default: "") != "" {
+        linebreak()
+        smallcaps(expediteur.pays)
+    }
+    if expediteur.at("telephone", default: "") != "" {
         [
             #linebreak()
             tél. : #raw(expediteur.telephone)
         ]
     }
-    if expediteur.email != "" {
+    if expediteur.at("email", default: "") != "" {
         [
             #linebreak()
             email : #link("mailto:" + expediteur.email)[#raw(expediteur.email)]
@@ -62,13 +66,13 @@
         [
             #destinataire.titre \
             #destinataire.voie \
-            #if destinataire.complement_adresse != "" {
+            #if destinataire.at("complement_adresse", default: "") != "" {
                 [
                     #destinataire.complement_adresse \
                 ]
             }
             #destinataire.code_postal #destinataire.commune
-            #if destinataire.sc != "" {
+            #if destinataire.at("sc", default: "") != "" {
                 [
                     #v(1cm)
                     s/c de #destinataire.sc \
@@ -92,7 +96,7 @@
         ]
     }
 set align(right + horizon)
-    if expediteur.signature == true {
+    if expediteur.at("signature", default: false) == true {
         v(-3cm)
     }
     [

--- a/src/lib.typ
+++ b/src/lib.typ
@@ -30,15 +30,12 @@
     doc,
 ) = {
     [
-        #expediteur.prenom #smallcaps[#expediteur.nom] \
+        #expediteur.prenom #smallcaps(expediteur.nom) \
         #expediteur.voie #h(1fr) #lieu, #date \
     ]
-    if expediteur.at("complement_adresse", default: "") != "" {
-        [
-            #expediteur.complement_adresse
-            #linebreak()
-        ]
-    }
+    if expediteur.at("complement_adresse", default: "") != "" [
+        #expediteur.complement_adresse \
+    ]
     [
         #expediteur.code_postal #expediteur.commune
     ]
@@ -46,18 +43,14 @@
         linebreak()
         smallcaps(expediteur.pays)
     }
-    if expediteur.at("telephone", default: "") != "" {
-        [
-            #linebreak()
-            tél. : #raw(expediteur.telephone)
-        ]
-    }
-    if expediteur.at("email", default: "") != "" {
-        [
-            #linebreak()
-            email : #link("mailto:" + expediteur.email)[#raw(expediteur.email)]
-        ]
-    }
+    if expediteur.at("telephone", default: "") != "" [
+        #linebreak()
+        tél. : #raw(expediteur.telephone)
+    ]
+    if expediteur.at("email", default: "") != "" [
+        #linebreak()
+        email : #link("mailto:" + expediteur.email, raw(expediteur.email))
+    ]
     v(1cm)
 
     grid(
@@ -66,18 +59,14 @@
         [
             #destinataire.titre \
             #destinataire.voie \
-            #if destinataire.at("complement_adresse", default: "") != "" {
-                [
-                    #destinataire.complement_adresse \
-                ]
-            }
+            #if destinataire.at("complement_adresse", default: "") != "" [
+                #destinataire.complement_adresse \
+            ]
             #destinataire.code_postal #destinataire.commune
-            #if destinataire.at("sc", default: "") != "" {
-                [
-                    #v(1cm)
-                    s/c de #destinataire.sc \
-                ]
-            }
+            #if destinataire.at("sc", default: "") != "" [
+                #v(1cm)
+                s/c de #destinataire.sc \
+            ]
         ],
     )
 

--- a/template/src/exemple.typ
+++ b/template/src/exemple.typ
@@ -10,8 +10,8 @@ expediteur: (
   complement_adresse: "",
   code_postal: "33320",
   commune: "Le Taillan-Médoc",
-  telephone: "01 23 45 67 89",
-  email: "etienne@laboetie.org",
+  telephone: "01 99 00 67 89",
+  email: "etienne@laboetie.example",
   signature: false, // indiquez true si ajout d’une image comme signature
 ),
 destinataire: (

--- a/template/src/exemple.typ
+++ b/template/src/exemple.typ
@@ -21,6 +21,7 @@ destinataire: (
   code_postal: "55000",
   commune: "Bar-le-Duc",
   sc: "",
+  marque_pliage: false, // indiquez true pour imprimer une marque de pliage
 ),
 lieu: "Camp Germignan",
 objet: [Ceci est un objet de courrier.],


### PR DESCRIPTION
J'ai repris la mise en page de l'en-tête de la lettre pour tout mettre sous la forme d'une unique grille. Les dimensions sont conçues pour correspondre aux enveloppes à fenêtre.

J'en ai profité pour ajouter une marque de pliage optionnelle, exactement placée pour un pliage en trois. Contrairement à celle insérée d'office par la classe LaTeX `lettre` qui est positionnée n'importe comment.

Cette PR vient après #10 et  #11 sur lesquels elle s'appuie. Vu le niveau de modifications, c'était à peu près impossible d'en faire une modification vraiment indépendante.