### PR TITLE
Ajout des références

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ Pour utiliser le template, il est possible de recopier le fichier exemple.
 - `objet` : l'objet du courrier, **requis**.
 - `date` : date à indiquer sous forme libre, **requis**.
 - `lieu` : lieu de rédaction, **requis**.
+- `ref` : référence du courrier, *facultatif*.
+- `vref` : votre référence (référence utilisée par le destinataire), *facultatif*.
+- `nref` : notre référence (référence utilisée par l'expéditeur), *facultatif*.
 - `appel` : formule d'appel, autrement dit formule initiale, désactivée par défaut. *Facultatif*.
 - `salutation` : formule de salutation, autrement dit formule finale, désactivée par défaut. *Facultatif*.
 - `pj` : permet d'indiquer la présence de pièces jointes.  Il est possible d'en faire une liste, par exemple :

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Pour utiliser le template, il est possible de recopier le fichier exemple.
 - `date` : date à indiquer sous forme libre, **requis**.
 - `lieu` : lieu de rédaction, **requis**.
 - `pj` : permet d'indiquer la présence de pièces jointes.  Il est possible d'en faire une liste, par exemple :
+- `marque_pliage` : `false` par défaut, mettre à `true` pour imprimer une petite ligne indiquant où plier la page pour la mettre dans une enveloppe DL ou C5/6. *Facultatif*.
 
 ```
 pj: [

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Pour utiliser le template, il est possible de recopier le fichier exemple.
 -  `expediteur.email` : l'email fourni sera affiché en police mono et cliquable. *Chaîne de caractères*, *facultatif*.
 - `expediteur.signature` : peut être `true` ou `false`, par défaut `false`. Prévient le paquet qu’une image de signature sera ajoutée, de manière à organiser la superposition de la signature et du nom apposé en fin de courrier.
 
-## Destinataire
+### Destinataire
 
 - `destinataire.titre` : titre du ou de la destinataire, **requis**.
 - `destinataire.voie` : numéro de voie et nom de la voie, **requis**.
@@ -35,7 +35,7 @@ Pour utiliser le template, il est possible de recopier le fichier exemple.
 - `destinataire.pays` : pays du ou de la destinataire, *facultatif*.
 - `destinataire.sc` : si le courrier est envoyé “sous couvert” d'une hiérarchie intermédiaire, spécifier cette autorité. *Facultatif*.
 
-## Lettre
+### Lettre
 
 - `objet` : l'objet du courrier, **requis**.
 - `date` : date à indiquer sous forme libre, **requis**.
@@ -53,10 +53,42 @@ pj: [
 	]
 ```
 - `enveloppe` : permet de générer une page à imprimer sur une enveloppe de la taille indiquée, qui peut être une chaîne contenant le nom d'un format courant (`c4`, `c5`, `c6`, `c56` ou `dl`) ou une spécification manuelle sous la forme `(<longueur>, <largeur>)`. *Facultatif*.
+- `affranchissement` : fournir une chaîne (code d'affranchissement) ou un contenu tel que `image("timbre.png")` pour imprimer un affranchissement dans la zone idoine de l'enveloppe. *Facultatif*.
 
 Le texte de la lettre proprement dite se situe après la configuration de la lettre.
 
 À la fin de la lettre, il est possible de décommenter les deux dernières lignes pour ajouter une image en guise de signature. Veillez dans ce cas à positionner la varibale `expediteur.signature` à `true`.
 
 
+## Notes
 
+### Affranchissement
+
+Les services postaux de plusieurs pays proposent des services en ligne d'affranchissement à domicile. Il s'agit :
+
+* soit de codes d'affranchissement à écrire sur l'enveloppe ;
+* soit de timbres à imprimer.
+
+Le premier cas est le plus facile à intégrer sur une enveloppe générée par formalettre, en précisant :
+
+```typm
+#show formalettre.with(
+    expediteur: (…),
+    destinataire: (…),
+    …,
+    enveloppe: "dl", // ou autre format, p. ex. "c5"
+    affranchissement: "<code d'affranchissement>",
+)
+```
+
+Dans le second cas, les timbres à imprimer ne sont malheureusement pas fournis sous forme d'image individuelle, mais dans un document PDF à imprimer sur feuille A4, sur planche d'étiquette ou sur feuille A4. Pour l'intégrer à l'enveloppe générée par formalettre, vous devez alors en extraire une image correspondant au timbre seul, puis remplir ainsi les paramètres de formalettre :
+
+```typm
+#show formalettre.with(
+    expediteur: (…),
+    destinataire: (…),
+    …,
+    enveloppe: "dl", // ou autre format, p. ex. "c5"
+    affranchissement: image("timbre.png"),
+)
+```

--- a/src/lib.typ
+++ b/src/lib.typ
@@ -196,13 +196,20 @@
     // │   │            filler #5              │   │ │ 20 mm │
     // └───┴───────────────────────────────────┴───┘ ┘ ──────┘
     // └───┴───────────────┴───┴───────────┴───┴───┘
-    // 25mm│     75mm       1fr     auto    1fr│25mm
+    // 25mm│ 75mm = 46.875% 1fr     auto    1fr│25mm
     //     └───────────────────────────────────┘
     //                      100%
     //
+    // For the sender column, we use a percentage instead of a fixed length.
+    // That percentage has been computed to result in the same length with an
+    // A4 page using standard Typst margins. This allows us to produce a
+    // relevant layout even with page sizes othen than A4, e.g. letter or A5
+    // (although there will be no compatibility with windowed enveloppe with
+    // such a small format).
+    //
     block(width: 100%, height: 75mm, spacing: 0pt,
         grid(
-            columns: (75mm, 1fr, auto, 1fr),
+            columns: (46.875%, 1fr, auto, 1fr),
             rows: (20mm, 1fr, auto, 1fr, 20mm),
             grid.cell(rowspan: 4,  // sender address and contact info
                 [

--- a/src/lib.typ
+++ b/src/lib.typ
@@ -91,34 +91,53 @@
 
     // Bloc d'adresse de l'expéditeur, utilisable pour l'en-tête et l'enveloppe
     expediteur.adresse = [
-            #expediteur.prenom #smallcaps(expediteur.nom) \
-            #expediteur.voie \
-            #if expediteur.complement_adresse != "" and expediteur.complement_adresse != [] [
-                #expediteur.complement_adresse \
-            ]
-            #expediteur.code_postal #expediteur.commune
-            #if expediteur.pays != "" and expediteur.pays != [] {
-                linebreak()
-                smallcaps(expediteur.pays)
-            }
+        #expediteur.prenom #smallcaps(expediteur.nom) \
+        #expediteur.voie \
+        #if expediteur.complement_adresse != "" and expediteur.complement_adresse != [] [
+            #expediteur.complement_adresse \
+        ]
+        #expediteur.code_postal #expediteur.commune
+        #if expediteur.pays != "" and expediteur.pays != [] {
+            linebreak()
+            smallcaps(expediteur.pays)
+        }
     ]
+
+    // Bloc de coordonnées de l'expéditeur, utilisées dans l'en-tête
+    if expediteur.telephone == "" and expediteur.email == "" {
+        expediteur.coordonnees = []
+    }
+    else {
+        expediteur.coordonnees = {
+            if expediteur.telephone != "" [
+                tél. : #link(
+                    "tel:"+ expediteur.telephone.replace(" ", "-"),
+                    expediteur.telephone) \
+            ]
+            if expediteur.email != "" [
+                email : #link(
+                    "mailto:" + expediteur.email,
+                    raw(expediteur.email)) \
+            ]
+        }
+    }
 
     // Bloc d'adresse du destinataire, utilisable pour l'en-tête et l'enveloppe
     destinataire.adresse = [
-            #destinataire.titre \
-            #destinataire.voie \
-            #if destinataire.complement_adresse != "" and destinataire.complement_adresse != [] [
-                #destinataire.complement_adresse \
-            ]
-            #destinataire.code_postal #destinataire.commune
-            #if destinataire.pays != "" and destinataire.pays != [] {
-                linebreak()
-                smallcaps(destinataire.pays)
-            }
-            #if destinataire.sc != "" and destinataire.sc != [] [
-                #v(2.5em)
-                s/c de #destinataire.sc \
-            ]
+        #destinataire.titre \
+        #destinataire.voie \
+        #if destinataire.complement_adresse != "" and destinataire.complement_adresse != [] [
+            #destinataire.complement_adresse \
+        ]
+        #destinataire.code_postal #destinataire.commune
+        #if destinataire.pays != "" and destinataire.pays != [] {
+            linebreak()
+            smallcaps(destinataire.pays)
+        }
+        #if destinataire.sc != "" and destinataire.sc != [] [
+            #v(2.5em)
+            s/c de #destinataire.sc \
+        ]
     ]
 
     // An windowed enveloppe looks like this:
@@ -187,16 +206,9 @@
             grid.cell(rowspan: 4,  // sender address and contact info
                 [
                     #expediteur.adresse
-                    #if expediteur.telephone != "" [
-                        #linebreak()
-                        tél. : #link(
-                            "tel:"+ expediteur.telephone.replace(" ", "-"),
-                            expediteur.telephone)
-                    ]
-                    #if expediteur.email != "" [
-                        #linebreak()
-                        email : #link("mailto:" + expediteur.email, raw(expediteur.email))
-                    ]
+                    #if expediteur.coordonnees != [] {
+                        par(expediteur.coordonnees)
+                    }
                 ]
             ),
             grid.cell(colspan: 3,  // place and date

--- a/src/lib.typ
+++ b/src/lib.typ
@@ -89,6 +89,38 @@
     destinataire.pays = destinataire.at("pays", default: "")
     destinataire.sc = destinataire.at("sc", default: "")
 
+    // Bloc d'adresse de l'expéditeur, utilisable pour l'en-tête et l'enveloppe
+    expediteur.adresse = [
+            #expediteur.prenom #smallcaps(expediteur.nom) \
+            #expediteur.voie \
+            #if expediteur.complement_adresse != "" and expediteur.complement_adresse != [] [
+                #expediteur.complement_adresse \
+            ]
+            #expediteur.code_postal #expediteur.commune
+            #if expediteur.pays != "" and expediteur.pays != [] {
+                linebreak()
+                smallcaps(expediteur.pays)
+            }
+    ]
+
+    // Bloc d'adresse du destinataire, utilisable pour l'en-tête et l'enveloppe
+    destinataire.adresse = [
+            #destinataire.titre \
+            #destinataire.voie \
+            #if destinataire.complement_adresse != "" and destinataire.complement_adresse != [] [
+                #destinataire.complement_adresse \
+            ]
+            #destinataire.code_postal #destinataire.commune
+            #if destinataire.pays != "" and destinataire.pays != [] {
+                linebreak()
+                smallcaps(destinataire.pays)
+            }
+            #if destinataire.sc != "" and destinataire.sc != [] [
+                #v(2.5em)
+                s/c de #destinataire.sc \
+            ]
+    ]
+
     // An windowed enveloppe looks like this:
     //                          220 mm
     //       ┌───────────────────────────────────────────┐
@@ -154,16 +186,7 @@
             rows: (20mm, 1fr, auto, 1fr, 20mm),
             grid.cell(rowspan: 4,  // sender address and contact info
                 [
-                    #expediteur.prenom #smallcaps(expediteur.nom) \
-                    #expediteur.voie \
-                    #if expediteur.complement_adresse != "" and expediteur.complement_adresse != [] [
-                        #expediteur.complement_adresse \
-                    ]
-                    #expediteur.code_postal #expediteur.commune
-                    #if expediteur.pays != "" and expediteur.pays != [] {
-                        linebreak()
-                        smallcaps(expediteur.pays)
-                    }
+                    #expediteur.adresse
                     #if expediteur.telephone != "" [
                         #linebreak()
                         tél. : #link(
@@ -184,27 +207,12 @@
                     #lieu, #date
                 ]
             ),
-            grid.cell(colspan: 3, []),  // filler #1
-            grid.cell[],                // filler #2
-            grid.cell[                  // sender address
-                #destinataire.titre \
-                #destinataire.voie \
-                #if destinataire.complement_adresse != "" and destinataire.complement_adresse != [] [
-                    #destinataire.complement_adresse \
-                ]
-                #destinataire.code_postal #destinataire.commune
-                #if destinataire.pays != "" and destinataire.pays != [] {
-                    linebreak()
-                    smallcaps(destinataire.pays)
-                }
-                #if destinataire.sc != "" and destinataire.sc != [] [
-                    #v(2.5em)
-                    s/c de #destinataire.sc \
-                ]
-            ],
-            grid.cell[],               // filler #3
-            grid.cell(colspan: 3, []), // filler #4
-            grid.cell(colspan: 4, []), // filler #5
+            grid.cell(colspan: 3, []),         // filler #1
+            grid.cell[],                       // filler #2
+            grid.cell[#destinataire.adresse],  // sender address
+            grid.cell[],                       // filler #3
+            grid.cell(colspan: 3, []),         // filler #4
+            grid.cell(colspan: 4, []),         // filler #5
         )
     )
 
@@ -285,26 +293,15 @@
         grid(
             columns: (3fr, auto, 1fr),
             rows: (6fr, auto, 1fr),
-            grid.cell(colspan: 3)[  // sender block
+            grid.cell(colspan: 3)[     // sender block
                 #set align(left + top)
                 Expéditeur :\
-                #expediteur.prenom #expediteur.nom \
-                #expediteur.voie \
-                #if expediteur.complement_adresse != "" [
-                    #expediteur.complement_adresse \
-                ]
-                #expediteur.code_postal #expediteur.commune
+                #expediteur.adresse
             ],
-            grid.cell[],  // filler #1
-            grid.cell[    // recipient block
+            grid.cell[],               // filler #1
+            grid.cell[                 // recipient block
                 #set align(left + horizon)
-                Destinataire :\
-                #destinataire.titre \
-                #destinataire.voie \
-                #if destinataire.complement_adresse != "" [
-                    #destinataire.complement_adresse \
-                ]
-                #expediteur.code_postal #expediteur.commune
+                #destinataire.adresse
             ],
             grid.cell[],               // filler #2
             grid.cell(colspan: 3, [])  // filler #3

--- a/src/lib.typ
+++ b/src/lib.typ
@@ -64,6 +64,9 @@
     objet: [],
     date: [],
     lieu: [],
+    ref: "",
+    vref: "",
+    nref: "",
     appel: "",
     salutation: "",
     pj: [],
@@ -243,6 +246,27 @@
     }
 
     v(1em)
+
+    if ref != "" [
+        Réf. #ref
+        #v(1em)
+    ]
+    else if vref != "" and nref != "" [
+        V/réf. #vref
+        #h(1fr)
+        N/Réf. #nref
+        #h(3fr)
+        #v(1em)
+    ]
+    else if vref != "" [
+        V/réf. #vref \
+        #v(1em)
+    ]
+    else if nref != "" [
+        N/réf. #nref \
+        #v(1em)
+    ]
+
     [*Objet : #objet*]
     
     v(1.8em)

--- a/src/lib.typ
+++ b/src/lib.typ
@@ -45,7 +45,9 @@
     }
     if expediteur.at("telephone", default: "") != "" [
         #linebreak()
-        tél. : #raw(expediteur.telephone)
+        tél. : #link(
+            "tel:"+ expediteur.telephone.replace(" ", "-"),
+            expediteur.telephone)
     ]
     if expediteur.at("email", default: "") != "" [
         #linebreak()

--- a/src/lib.typ
+++ b/src/lib.typ
@@ -263,8 +263,7 @@
         pagebreak()
 
         set page(
-            width: format.width, height: format.height,
-            margin: (left: 1cm, top: 1cm, rest: 2cm))
+            width: format.width, height: format.height)
 
         // Set text size to an appropriate value for the chosen envelope
         // size. It must grow with the envelope size, but not too much
@@ -275,7 +274,7 @@
 
         // We use the following grid layout:
         // ┌──────────────────────────────────────────┐ ┐
-        // │                  margin                  │ │ 25 mm
+        // │                  margin                  │ │ default margin
         // │   ┌──────────────────────────────────┐   │ ┤
         // │   │ Sender                           │   │ │
         // │   │ Address                          │   │ │
@@ -286,10 +285,12 @@
         // │   │    filler    │ Recipient    │ f. │   │ │ auto
         // │   │    #1        │ Address      │ #2 │   │ │
         // │   ├──────────────┴──────────────┴────┤   │ ┤
-        // │   │            filler #3             │   │ │ 1fr
+        // │   │            filler #3             │   │ │ default margin
         // └───┴──────────────────────────────────┴───┘ ┘
         // └───┴──────────────┴──────────────┴────┴───┘
-        //  25mm      3fr           auto      1fr  25mm
+        //  def.      3fr           auto      1fr  def.
+        //  margin                                 margin
+        //
         grid(
             columns: (3fr, auto, 1fr),
             rows: (6fr, auto, 1fr),

--- a/src/lib.typ
+++ b/src/lib.typ
@@ -48,51 +48,123 @@
     // destinataire.commune is required
     destinataire.pays = destinataire.at("pays", default: "")
     destinataire.sc = destinataire.at("sc", default: "")
-    [
-        #expediteur.prenom #smallcaps(expediteur.nom) \
-        #expediteur.voie #h(1fr) #lieu, #date \
-    ]
-    if expediteur.complement_adresse != "" and expediteur.complement_adresse != [] [
-        #expediteur.complement_adresse \
-    ]
-    [
-        #expediteur.code_postal #expediteur.commune
-    ]
-    if expediteur.pays != "" and expediteur.pays != [] {
-        linebreak()
-        smallcaps(expediteur.pays)
-    }
-    if expediteur.telephone != "" [
-        #linebreak()
-        tél. : #link(
-            "tel:"+ expediteur.telephone.replace(" ", "-"),
-            expediteur.telephone)
-    ]
-    if expediteur.email != "" [
-        #linebreak()
-        email : #link("mailto:" + expediteur.email, raw(expediteur.email))
-    ]
-    v(1cm)
 
-    grid(
-        columns: (1fr, 5cm),
-        grid.cell(""),
-        [
-            #destinataire.titre \
-            #destinataire.voie \
-            #if destinataire.complement_adresse != "" and destinataire.complement_adresse != [] [
-                #destinataire.complement_adresse \
-            ]
-            #destinataire.code_postal #destinataire.commune
-            #if destinataire.sc != "" and destinataire.sc != [] [
-                #v(1cm)
-                s/c de #destinataire.sc \
-            ]
-        ],
+    // An windowed enveloppe looks like this:
+    //                          220 mm
+    //       ┌───────────────────────────────────────────┐
+    //     ┌ ┌───────────────────────────────────────────┐ ┐
+    //     │ │                                           │ │
+    //     │ │                                           │ │ 45 mm
+    //     │ │                                           │ │
+    //     │ │                   ┌───────────────────┐   │ ┤
+    // 110 │ │                   │                   │   │ │
+    //  mm │ │                   │                   │   │ │ 45 mm
+    //     │ │                   │                   │   │ │
+    //     │ │                   └───────────────────┘   │ ┤
+    //     │ │                                           │ │ 20 mm
+    //     └ └───────────────────────────────────────────┘ ┘
+    //       └───────────────────┴───────────────────┴───┘
+    //            100 mm              100 mm      20 mm
+    //
+    // The folded letter is 210 mm large and 99 mm high, and can
+    // therefore more horizontally by 10 mm and vertically by 11 mm.
+    // This results in the following safe zone for the recipient
+    // address:
+    // ┌───────────────────────────────────────────┐ ┐
+    // │                                           │ │
+    // │                                           │ │ 45 mm
+    // │                                           │ │
+    // │                   ┌───────────────────┐   │ ┤
+    // │                   │                   │   │ │ 34 mm
+    // │                   │                   │   │ │
+    // │                   └───────────────────┘   │ ┤
+    // │                                           │ │ 20 mm
+    // └─────────────── fold ── here ──────────────┘ ┘
+    // └───────────────────┴───────────────────┴───┘
+    //         100 mm              90 mm       20 mm
+    //
+    // We use a (width: 100%, height: 100mm) box containing a grid with
+    // some merged cells to position sender, place and date, and
+    // recipient. Filling rows and columns with fractional dimensions
+    // are here to center the recipient address block within its
+    // window, resulting in a much better-looking layout than just
+    // positionning it statically.
+    // ┌───────────────────────────────────────────┐ ┐
+    // │                  margin                   │ │ 25 mm
+    // │   ┌───────────────┬───────────────────┐   │ ┤ ──────┐
+    // │   │ Sender        │       place, date │   │ │ 20 mm │
+    // │   │ Address       ├───────────────────┤   │ ┤       │
+    // │   │               │     filler #1     │   │ │ 1fr   │
+    // │   │ Phone         ├───┬───────────┬───┤   │ ┤       │
+    // │   │ Email         │f. │ Recipient │f. │   │ │ auto  │
+    // │   │               │#2 │ Address   │#3 │   │ │       │ 75 mm
+    // │   │               ├───┴───────────┴───┤   │ ┤       │
+    // │   │               │     filler #4     │   │ │ 1fr   │
+    // │   ├───────────────┴───────────────────┤   │ ┤       │
+    // │   │            filler #5              │   │ │ 20 mm │
+    // └───┴───────────────────────────────────┴───┘ ┘ ──────┘
+    // └───┴───────────────┴───┴───────────┴───┴───┘
+    // 25mm│     75mm       1fr     auto    1fr│25mm
+    //     └───────────────────────────────────┘
+    //                      100%
+    //
+    block(width: 100%, height: 75mm, spacing: 0pt,
+        grid(
+            columns: (75mm, 1fr, auto, 1fr),
+            rows: (20mm, 1fr, auto, 1fr, 20mm),
+            grid.cell(rowspan: 4,  // sender address and contact info
+                [
+                    #expediteur.prenom #smallcaps(expediteur.nom) \
+                    #expediteur.voie \
+                    #if expediteur.complement_adresse != "" and expediteur.complement_adresse != [] [
+                        #expediteur.complement_adresse \
+                    ]
+                    #expediteur.code_postal #expediteur.commune
+                    #if expediteur.pays != "" and expediteur.pays != [] {
+                        linebreak()
+                        smallcaps(expediteur.pays)
+                    }
+                    #if expediteur.telephone != "" [
+                        #linebreak()
+                        tél. : #link(
+                            "tel:"+ expediteur.telephone.replace(" ", "-"),
+                            expediteur.telephone)
+                    ]
+                    #if expediteur.email != "" [
+                        #linebreak()
+                        email : #link("mailto:" + expediteur.email, raw(expediteur.email))
+                    ]
+                ]
+            ),
+            grid.cell(colspan: 3,  // place and date
+                [
+                    #set align(right)
+                    // place and date should be on second line
+                    #linebreak()
+                    #lieu, #date
+                ]
+            ),
+            grid.cell(colspan: 3, []),  // filler #1
+            grid.cell[],                // filler #2
+            grid.cell[                  // sender address
+                #destinataire.titre \
+                #destinataire.voie \
+                #if destinataire.complement_adresse != "" and destinataire.complement_adresse != [] [
+                    #destinataire.complement_adresse \
+                ]
+                #destinataire.code_postal #destinataire.commune
+                #if destinataire.sc != "" and destinataire.sc != [] [
+                    #v(1cm)
+                    s/c de #destinataire.sc \
+                ]
+            ],
+            grid.cell[],               // filler #3
+            grid.cell(colspan: 3, []), // filler #4
+            grid.cell(colspan: 4, []), // filler #5
+        )
     )
 
-    v(1.7cm)
-
+    v(1em)
     [*Objet : #objet*]
     
     v(0.7cm)

--- a/src/lib.typ
+++ b/src/lib.typ
@@ -29,6 +29,7 @@
     date: [],
     lieu: [],
     pj: [],
+    marque_pliage: false,
     doc,
 ) = {
     // expediteur.prenom is required
@@ -163,6 +164,12 @@
             grid.cell(colspan: 4, []), // filler #5
         )
     )
+
+    if marque_pliage {
+        place(
+            top + left, dx: -25mm, dy: 74mm,
+            line(length: 1cm, stroke: .1pt))
+    }
 
     v(1em)
     [*Objet : #objet*]

--- a/src/lib.typ
+++ b/src/lib.typ
@@ -33,7 +33,7 @@
         #expediteur.prenom #smallcaps[#expediteur.nom] \
         #expediteur.voie #h(1fr) #lieu, #date \
     ]
-    if expediteur.complement_adresse != "" {
+    if expediteur.at("complement_adresse", default: "") != "" {
         [
             #expediteur.complement_adresse
             #linebreak()
@@ -42,13 +42,17 @@
     [
         #expediteur.code_postal #expediteur.commune
     ]
-    if expediteur.telephone != "" {
+    if expediteur.at("pays", default: "") != "" {
+        linebreak()
+        smallcaps(expediteur.pays)
+    }
+    if expediteur.at("telephone", default: "") != "" {
         [
             #linebreak()
             tél. : #raw(expediteur.telephone)
         ]
     }
-    if expediteur.email != "" {
+    if expediteur.at("email", default: "") != "" {
         [
             #linebreak()
             email : #link("mailto:" + expediteur.email)[#raw(expediteur.email)]
@@ -62,13 +66,13 @@
         [
             #destinataire.titre \
             #destinataire.voie \
-            #if destinataire.complement_adresse != "" {
+            #if destinataire.at("complement_adresse", default: "") != "" {
                 [
                     #destinataire.complement_adresse \
                 ]
             }
             #destinataire.code_postal #destinataire.commune
-            #if destinataire.sc != "" {
+            #if destinataire.at("sc", default: "") != "" {
                 [
                     #v(1cm)
                     s/c de #destinataire.sc \
@@ -92,7 +96,7 @@
         ]
     }
 set align(right + horizon)
-    if expediteur.signature == true {
+    if expediteur.at("signature", default: false) == true {
         v(-3cm)
     }
     [

--- a/src/lib.typ
+++ b/src/lib.typ
@@ -69,6 +69,7 @@
     pj: [],
     marque_pliage: false,
     enveloppe: none,
+    affranchissement: none,
     doc,
 ) = {
     // expediteur.prenom is required
@@ -285,32 +286,44 @@
         set text(size: calc.sqrt(format.height.cm() / 11) * 11pt)
 
         // We use the following grid layout:
-        // ┌──────────────────────────────────────────┐ ┐
-        // │                  margin                  │ │ default margin
-        // │   ┌──────────────────────────────────┐   │ ┤
-        // │   │ Sender                           │   │ │
-        // │   │ Address                          │   │ │
-        // │   │                                  │   │ │ 6fr
-        // │   │                                  │   │ │
-        // │   │                                  │   │ │
-        // │   ├──────────────┬──────────────┬────┤   │ ┤
+        //              1fr              auto
+        //     ┌────────────────────┬─────────────┐
+        // ┌──────────────────────────────────────────┐
+        // │             default margin               │
+        // │   ┌────────────────────┬─────────────┐   │ ┐
+        // │   │ Sender             │             │   │ │
+        // │   │ Address            │             │   │ │
+        // │   │                    │             │   │ │ 6fr
+        // │   │                    │             │   │ │
+        // │   │                    │             │   │ │
+        // │   ├──────────────┬─────┴────────┬────┤   │ ┤
         // │   │    filler    │ Recipient    │ f. │   │ │ auto
         // │   │    #1        │ Address      │ #2 │   │ │
-        // │   ├──────────────┴──────────────┴────┤   │ ┤
-        // │   │            filler #3             │   │ │ default margin
-        // └───┴──────────────────────────────────┴───┘ ┘
-        // └───┴──────────────┴──────────────┴────┴───┘
-        //  def.      3fr           auto      1fr  def.
-        //  margin                                 margin
+        // │   ├──────────────┴──────────────┴────┤   │ ┘
+        // │   │            filler #3             │   │
+        // └───┴──────────────────────────────────┴───┘
+        //     └──────────────┴──────────────┴────┘
+        //            3fr           auto      1fr
         //
         grid(
             columns: (3fr, auto, 1fr),
             rows: (6fr, auto, 1fr),
-            grid.cell(colspan: 3)[     // sender block
-                #set align(left + top)
-                Expéditeur :\
-                #expediteur.adresse
-            ],
+            grid.cell(colspan: 3,      // sender + stamp line
+                grid(
+                    columns: (1fr, auto),
+                    grid.cell[         // sender block
+                        #set align(left + top)
+                        Expéditeur :\
+                        #expediteur.adresse
+                    ],
+                    grid.cell[         // stamp block
+                        #set align(right + top)
+                        #if affranchissement != none {
+                            affranchissement
+                        }
+                    ]
+                )
+            ),
             grid.cell[],               // filler #1
             grid.cell[                 // recipient block
                 #set align(left + horizon)

--- a/src/lib.typ
+++ b/src/lib.typ
@@ -193,6 +193,10 @@
                     #destinataire.complement_adresse \
                 ]
                 #destinataire.code_postal #destinataire.commune
+                #if destinataire.pays != "" and destinataire.pays != [] {
+                    linebreak()
+                    smallcaps(destinataire.pays)
+                }
                 #if destinataire.sc != "" and destinataire.sc != [] [
                     #v(2.5em)
                     s/c de #destinataire.sc \

--- a/src/lib.typ
+++ b/src/lib.typ
@@ -30,15 +30,12 @@
     doc,
 ) = {
     [
-        #expediteur.prenom #smallcaps[#expediteur.nom] \
+        #expediteur.prenom #smallcaps(expediteur.nom) \
         #expediteur.voie #h(1fr) #lieu, #date \
     ]
-    if expediteur.at("complement_adresse", default: "") != "" {
-        [
-            #expediteur.complement_adresse
-            #linebreak()
-        ]
-    }
+    if expediteur.at("complement_adresse", default: "") != "" [
+        #expediteur.complement_adresse \
+    ]
     [
         #expediteur.code_postal #expediteur.commune
     ]
@@ -46,18 +43,14 @@
         linebreak()
         smallcaps(expediteur.pays)
     }
-    if expediteur.at("telephone", default: "") != "" {
-        [
-            #linebreak()
-            tél. : #raw(expediteur.telephone)
-        ]
-    }
-    if expediteur.at("email", default: "") != "" {
-        [
-            #linebreak()
-            email : #link("mailto:" + expediteur.email)[#raw(expediteur.email)]
-        ]
-    }
+    if expediteur.at("telephone", default: "") != "" [
+        #linebreak()
+        tél. : #raw(expediteur.telephone)
+    ]
+    if expediteur.at("email", default: "") != "" [
+        #linebreak()
+        email : #link("mailto:" + expediteur.email, raw(expediteur.email))
+    ]
     v(1cm)
 
     grid(
@@ -66,18 +59,14 @@
         [
             #destinataire.titre \
             #destinataire.voie \
-            #if destinataire.at("complement_adresse", default: "") != "" {
-                [
-                    #destinataire.complement_adresse \
-                ]
-            }
+            #if destinataire.at("complement_adresse", default: "") != "" [
+                #destinataire.complement_adresse \
+            ]
             #destinataire.code_postal #destinataire.commune
-            #if destinataire.at("sc", default: "") != "" {
-                [
-                    #v(1cm)
-                    s/c de #destinataire.sc \
-                ]
-            }
+            #if destinataire.at("sc", default: "") != "" [
+                #v(1cm)
+                s/c de #destinataire.sc \
+            ]
         ],
     )
 

--- a/template/src/exemple.typ
+++ b/template/src/exemple.typ
@@ -10,8 +10,8 @@ expediteur: (
   complement_adresse: "",
   code_postal: "33320",
   commune: "Le Taillan-Médoc",
-  telephone: "01 23 45 67 89",
-  email: "etienne@laboetie.org",
+  telephone: "01 99 00 67 89",
+  email: "etienne@laboetie.example",
   signature: false, // indiquez true si ajout d’une image comme signature
 ),
 destinataire: (

--- a/template/src/exemple.typ
+++ b/template/src/exemple.typ
@@ -21,6 +21,7 @@ destinataire: (
   code_postal: "55000",
   commune: "Bar-le-Duc",
   sc: "",
+  marque_pliage: false, // indiquez true pour imprimer une marque de pliage
 ),
 lieu: "Camp Germignan",
 objet: [Ceci est un objet de courrier.],

--- a/template/src/exemple.typ
+++ b/template/src/exemple.typ
@@ -25,6 +25,9 @@ destinataire: (
 lieu: "Camp Germignan",
 objet: [Ceci est un objet de courrier.],
 date: [le 7 juin 1559],
+ref: "1559/06/0001",    // au besoin, préciser à la place
+                        // vref: "<réf. destinataire>
+                        // nref: "<réf. expéditeur>
 appel: "Cher ami,",
 salutation: "Veuillez agréer, cher ami, l'assurance de mes chaleureuses salutations.",
 pj: "",

--- a/template/src/exemple.typ
+++ b/template/src/exemple.typ
@@ -28,10 +28,15 @@ date: [le 7 juin 1559],
 appel: "Cher ami,",
 salutation: "Veuillez agréer, cher ami, l'assurance de mes chaleureuses salutations.",
 pj: "",
-marque_pliage: false, // indiquez true pour imprimer une marque de pliage
-enveloppe: none,      // pour générer une page à imprimer sur enveloppe,
-                      // indiquez un format d'enveloppe, par exemple
-                      // "c4", "c5", "c6", "c56" ou "dl"
+marque_pliage: false,   // indiquez true pour imprimer une marque de pliage
+                        //
+enveloppe: none,        // indiquez un format d'enveloppe, par exemple
+                        // "c4", "c5", "c6", "c56" ou "dl"
+                        // pour générer une page à imprimer sur enveloppe,
+                        //
+affranchissement: none, // fournir un code d'affranchissement ou un contenu
+                        // d'image de timbre pour qu'il soit imprimé
+                        // dans la zone idoine de l'enveloppe
 )
 
 // Le corps du document remplace cette fonction

--- a/template/src/exemple.typ
+++ b/template/src/exemple.typ
@@ -21,7 +21,6 @@ destinataire: (
   code_postal: "55000",
   commune: "Bar-le-Duc",
   sc: "",
-  marque_pliage: false, // indiquez true pour imprimer une marque de pliage
 ),
 lieu: "Camp Germignan",
 objet: [Ceci est un objet de courrier.],
@@ -29,9 +28,10 @@ date: [le 7 juin 1559],
 appel: "Cher ami,",
 salutation: "Veuillez agréer, cher ami, l'assurance de mes chaleureuses salutations.",
 pj: "",
-envelope: none, // pour générer une page à imprimer sur enveloppe,
-                 // indiquez un format d'enveloppe, par exemple
-                 // "c4", "c5", "c6", "c56" ou "dl"
+marque_pliage: false, // indiquez true pour imprimer une marque de pliage
+enveloppe: none,      // pour générer une page à imprimer sur enveloppe,
+                      // indiquez un format d'enveloppe, par exemple
+                      // "c4", "c5", "c6", "c56" ou "dl"
 )
 
 // Le corps du document remplace cette fonction


### PR DESCRIPTION
Cette demande de fusion vient après #24, et ajoute une prise en charge des références (optionnelles) d'un courrier :

* `ref` pour une référence simple, commune à l'expéditeur et au destinataire ;
* `vref` et `nref` pour des références spécifiques au destinataire (votre référence) et à l'expéditeur (notre référence).

Closes: #6