### PR TITLE
Rendre l'objet optionnel

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Pour utiliser le template, il est possible de recopier le fichier exemple.
 
 ### Lettre
 
-- `objet` : l'objet du courrier, **requis**.
+- `objet` : l'objet du courrier, *facultatif*.
 - `date` : date à indiquer sous forme libre, **requis**.
 - `lieu` : lieu de rédaction, **requis**.
 - `appel` : formule d'appel, autrement dit formule initiale, désactivée par défaut. *Facultatif*.

--- a/src/lib.typ
+++ b/src/lib.typ
@@ -243,9 +243,10 @@
     }
 
     v(1em)
-    [*Objet : #objet*]
-    
-    v(1.8em)
+    if objet != "" and objet != [] [
+        *Objet : #objet*
+        #v(1.8em)
+    ]
 
     set par(justify: true)
 


### PR DESCRIPTION
Cette demande de fusion vient après #24, et rend l'objet optionnel. En effet il n'est pas rare de ne pas indiquer d'objet lorsqu'on écrit à des proches.

Closes: #18