### PR TITLE
Ajout des infos envoi optionnelles

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Pour utiliser le template, il est possible de recopier le fichier exemple.
 - `objet` : l'objet du courrier, **requis**.
 - `date` : date à indiquer sous forme libre, **requis**.
 - `lieu` : lieu de rédaction, **requis**.
+- `envoi` : informations d'envoi, par exemple « Recommandé avec accusé de réception numéro XXXXXXXX », *facultatif*.
 - `appel` : formule d'appel, autrement dit formule initiale, désactivée par défaut. *Facultatif*.
 - `salutation` : formule de salutation, autrement dit formule finale, désactivée par défaut. *Facultatif*.
 - `pj` : permet d'indiquer la présence de pièces jointes.  Il est possible d'en faire une liste, par exemple :

--- a/src/lib.typ
+++ b/src/lib.typ
@@ -65,6 +65,7 @@
 #let lettre(
     expediteur: expediteur,
     destinataire: destinataire,
+    envoi: [],
     objet: [],
     date: [],
     lieu: [],
@@ -256,6 +257,11 @@
     }
 
     v(1em)
+
+    if not_empty(envoi) {
+        par(envoi)
+    }
+
     [*Objet : #objet*]
     
     v(1.8em)

--- a/template/src/exemple.typ
+++ b/template/src/exemple.typ
@@ -28,6 +28,9 @@ destinataire: (
 lieu: "Camp Germignan",
 objet: [Ceci est un objet de courrier.],
 date: [le 7 juin 1559],
+// Décommenter la ligne suivante pour afficher des informations d'envoi suivi
+// ou recommandé
+// envoi: [Lettre suivie numéro XXXXXXXX],
 appel: "Cher ami,",
 salutation: "Veuillez agréer, cher ami, l'assurance de mes chaleureuses salutations.",
 pj: "",


### PR DESCRIPTION
Cette branche, qui s'applique après #24 qu'elle inclut, permet de préciser, de façon facultative, des informations d'envoi, typiquement le fait que la lettre est suivie ou recommandée avec un numéro donné. Par exemple :

```typc
lettre(
    …
    envoi: [Lettre recommandée A/R numéro XXXXXX],
)
```

Ça s'affiche juste avant l'objet. (Certains écrivent cela ailleurs mais ce n'est pas très bien défini)

Closes: #30