### PR TITLE
Version 0.2

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 BSD 3-Clause License
 
 Copyright (c) 2024, Brendan Chabannes <brendan.chabannes@wyrm.fr>
+              2025, Tanguy Ortolo <tanguy+typst@ortolo.eu>
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/typst.toml
+++ b/typst.toml
@@ -1,6 +1,6 @@
 [package]
 name = "formalettre"
-version = "0.1.3"
+version = "0.2.0"
 entrypoint = "src/lib.typ"
 authors = ["Brndan <@Brndan>", "Elessar <tanguy+typst@ortolo.eu>"]
 license = "BSD-3-Clause"

--- a/typst.toml
+++ b/typst.toml
@@ -2,7 +2,7 @@
 name = "formalettre"
 version = "0.1.3"
 entrypoint = "src/lib.typ"
-authors = ["@Brndan"]
+authors = ["Brndan <@Brndan>", "Elessar <tanguy+typst@ortolo.eu>"]
 license = "BSD-3-Clause"
 description = "French formal letter template"
 repository = "https://github.com/Brndan/lettre"


### PR DESCRIPTION
Ce qu'il faut pour passer à une version 0.2.0 et mettre à jour la liste des auteurs.

Sauf un tag Git, à faire à la main vu que ce n'est pas dans le code lui-même évidemment.

À fusionner après ce qu'on veut mettre dans ladite version 0.2.0.