### PR TITLE
Correction du formatage des coordonées téléphoniques/email

### DIFF
--- a/src/lib.typ
+++ b/src/lib.typ
@@ -208,13 +208,13 @@
     // coordonnées de l'expéditeur
     if type(expediteur.email) == str or type(expediteur.email) == content {
         expediteur.coordonnees.insert(0, ([], lien-email(expediteur.email)))
-    } else if type(expediteur.telephone) == array {
+    } else if type(expediteur.email) == array {
         expediteur.coordonnees.insert(0, (expediteur.email.at(0), lien-email(expediteur.email.at(1))))
     }
     if type(expediteur.telephone) == str or type(expediteur.telephone) == content {
         expediteur.coordonnees.insert(0, ([], lien-tel(expediteur.telephone)))
     } else if type(expediteur.telephone) == array {
-        expediteur.coordonnees.insert(0, (expediteur.telephone.at(0), lien-email(expediteur.telephone.at(1))))
+        expediteur.coordonnees.insert(0, (expediteur.telephone.at(0), lien-tel(expediteur.telephone.at(1))))
     }
 
     // Bloc de coordonnées de l'expéditeur, utilisées dans l'en-tête


### PR DESCRIPTION
Sous `formalettre` 0.3.0, les exemples fournis dans la documentation de fonctionnent pas correctement :

 - donner un couple (préfixe, numéro) pour le paramètre `telephone`, mais sans champ `email`, provoque une erreur :
```typc
#import "formalettre/src/lib.typ": *

#show: lettre.with(
  expediteur: (
    nom: "",
    adresse: "",
    commune: "",
    telephone: ([Tél.], "0x xx xx xx xx"),
  ),
  destinataire: (
    nom: "",
    adresse: "",
    commune: "",
  ),
  date: "",
  lieu: "",
)
```

```
error: type none has no method `at`
    ┌─ formalettre/src/lib.typ:212:59
    │
212 │         expediteur.coordonnees.insert(0, (expediteur.email.at(0), lien-email(expediteur.email.at(1))))
    │                                                            ^^
```

 - donner un couple (préfixe, coordonnées) pour aux deux paramètres `telephone` et `email` font que le numéro de téléphone est formatté comme une adresse mail plutôt qu'un numéro de téléphone.

Le patch ci-joint corrige ces deux problèmes.
